### PR TITLE
Checking for pending users every two hours

### DIFF
--- a/app/jobs/scheduled/pending_users_reminder.rb
+++ b/app/jobs/scheduled/pending_users_reminder.rb
@@ -3,7 +3,7 @@ require_dependency 'admin_user_index_query'
 module Jobs
 
   class PendingUsersReminder < Jobs::Scheduled
-    every 9.hours
+    every 2.hours
 
     def execute(args)
       if SiteSetting.must_approve_users


### PR DESCRIPTION
Checking for pending users every nine hours seems not being enough.